### PR TITLE
Instead of using dateMenu's weather client, create a new weather client

### DIFF
--- a/weatheroclock@CleoMenezesJr.github.io/extension.js
+++ b/weatheroclock@CleoMenezesJr.github.io/extension.js
@@ -18,7 +18,8 @@
  * If this extension breaks your desktop you get to keep all of the pieces...
  */
 
-const { Clutter, GLib, GObject, St } = imports.gi;
+const { Clutter, GLib, GObject, GWeather, St } = imports.gi;
+const Weather = imports.misc.weather;
 const ExtensionUtils = imports.misc.extensionUtils;
 const [major, minor] = imports.misc.config.PACKAGE_VERSION.split(".").map((s) =>
   Number(s)
@@ -32,7 +33,7 @@ function enable() {
   if (!panelWeather) {
     statusArea = imports.ui.main.panel.statusArea;
     dateMenu = statusArea.dateMenu;
-    weather = dateMenu._weatherItem._weatherClient;
+    weather = new Weather.WeatherClient();
     network =
       major < 43
         ? statusArea.aggregateMenu._network


### PR DESCRIPTION
Instead of using the WeatherClient created and used by statusArea.dateMenu._weatherItem, create a new WeatherClient specifically for us. The dateMenu does some funny stuff with its WeatherClient, and I think that that was causing us some issues.
By creating and using our own WeatherClient we are able to have more control over its behavior.

It connects to GNOME Weather in the same way as the dateMenu does, so there is no change to its usage. 

This addresses #14.