### PR TITLE
Don't hardcode the icon size

### DIFF
--- a/weatheroclock@CleoMenezesJr.github.io/extension.js
+++ b/weatheroclock@CleoMenezesJr.github.io/extension.js
@@ -97,7 +97,7 @@ const PanelWeather = GObject.registerClass(
       this._signals = [];
 
       this._icon = new St.Icon({
-        icon_size: 16,
+        style_class: 'system-status-icon',
       });
 
       this.add_child(this._icon);


### PR DESCRIPTION
When fractional scaling is used, the weather icon remains small, and does not follow the size of other status icons. Add the 'system-status-icon' class instead of hard-coding the size to make it the same as other status icons.