### PR TITLE
Update weather info only if loaded

### DIFF
--- a/weatheroclock@CleoMenezesJr.github.io/extension.js
+++ b/weatheroclock@CleoMenezesJr.github.io/extension.js
@@ -147,10 +147,12 @@ const PanelWeather = GObject.registerClass(
     }
 
     _onWeatherInfoUpdate(weather) {
-      this._icon.icon_name = weather.info.get_symbolic_icon_name();
-      // "--" is not a valid temp...
-      this._label.text = weather.info.get_temp_summary().replace("--", "");
-      this.visible = this._icon.icon_name && this._label.text;
+      if (!weather.loading) {
+        this._icon.icon_name = weather.info.get_symbolic_icon_name();
+        // "--" is not a valid temp...
+        this._label.text = weather.info.get_temp_summary().replace("--", "");
+        this.visible = this._icon.icon_name && this._label.text;
+      }
     }
 
     _onNetworkIconNotifyEvents(networkIcon) {


### PR DESCRIPTION
On each update, the 'changed' signal is emitted twice, once when it starts to load, and once again when it's loaded. This causes a noticeable flicker, because the weather info is not available when 'weather.loading' is true.

This fixes the problem reported here: https://github.com/CleoMenezesJr/weather-oclock/issues/23